### PR TITLE
Implement a CLI for `tilted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog for `titled`
 
+## Unreleased
+
+- Added a command-line interface ([`409df2cd`])
+
+- Fixed an error-by-design that caused errors during lexical analysis to be ignored ([`01dd2d6f`])
+
+[`409df2cd`]: https://github.com/SaltedPeanutButter/cal/commit/409df2cdfb007e3a0a3568b0b0d61fb964dbaa30
+[`01dd2d6f`]: https://github.com/SaltedPeanutButter/cal/commit/01dd2d6f68d1c1a1794cf8576e45e0c10c4e9b54
+
 ## Version 0.1.1
 
 - Added support for implicit multiplication ([`b560ed8f`])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,94 @@
 version = 3
 
 [[package]]
+name = "argh"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tilted"
 version = "0.1.1"
+dependencies = [
+ "argh",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,9 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["cli"]
+cli = ["argh"]
+
 [dependencies]
+argh = { version = ">=0.1", optional = true }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,32 @@
+//! This module implements the command-line interface for [`tilted`](crate).
+use argh::FromArgs;
+
+use crate::{Lexer, Parser};
+
+/// A non-Turing-complete interpreted programming 'language' that can do maths
+/// (only).
+#[derive(Debug, FromArgs)]
+pub struct Cli {
+    /// user input
+    #[argh(positional)]
+    input: String,
+}
+
+impl Cli {
+    pub fn start(&self) -> u8 {
+        let lexer = Lexer::from_source_code(&self.input);
+        let mut parser = Parser::from_lexer(lexer);
+        let result = parser.parse();
+
+        match result {
+            Ok(node) => {
+                println!("{}", node.evaluate());
+                0
+            }
+            Err(e) => {
+                eprintln!("{}", e);
+                1
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,15 @@
 #![warn(rustdoc::all)]
 
 pub mod ast;
+#[cfg(feature = "cli")]
+pub mod cli;
 pub mod error;
 pub mod lexer;
 pub mod macros;
 pub mod parser;
 
 pub use ast::{BinaryAction, BinaryNode, NodeBox, Number, PlainNode, UnaryAction, UnaryNode};
+pub use cli::Cli;
 pub use error::{LexError, ParseError, TilError};
 pub use lexer::{Lexer, Operator, Span, Token, TokenKind};
 pub use parser::Parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,8 @@
+use std::process::exit;
+
+use tilted::{self, Cli};
+
+fn main() {
+    let cli: Cli = argh::from_env();
+    exit(cli.start().into())
+}


### PR DESCRIPTION
This PR implements a quick command-line interface for `tilted`.

It was initially planned to do this by hand; however, it quickly became apparent that adding support for extra CLI functionalities in the future would become a pain in the a**. Hence, `argh` will be used instead.

`clap` was also considered as a potential framework. However, it is too OP for now and would cause unnecessarily long compile time.